### PR TITLE
Add CMake support, use allocatable arrays in Fortran

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(
+  STREAM
+  VERSION 1.0
+  DESCRIPTION "STREAM benchmark"
+  LANGUAGES C Fortran)
+
+# The C STREAM benchmark only requires
+# stream.c
+add_executable(stream_c.exe stream.c)
+
+# The Fortran STREAM benchmark requires
+# stream.f and mysecond.o from mysecond.c
+add_executable(stream_f.exe stream.f mysecond.c)
+
+# Look for OpenMP support is found, link it to the executables
+# Note that if you are using clang on macOS, you will need to
+# install libomp via Homebrew and then set the following
+# environment variables:
+#   export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+# see https://www.scivision.dev/cmake-openmp/ for more details
+
+find_package(OpenMP COMPONENTS C Fortran)
+# Use a generator expression to link OpenMP to the executables
+target_link_libraries(
+  stream_c.exe 
+  PRIVATE
+  $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>
+)
+
+target_link_libraries(
+  stream_f.exe 
+  PRIVATE
+  $<$<BOOL:${OpenMP_Fortran_FOUND}>:OpenMP::OpenMP_Fortran>
+)
+
+# Per @scivision, ignore the build directory
+if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  # Git auto-ignore out-of-source build directory
+  file(GENERATE OUTPUT .gitignore CONTENT "*")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,21 +22,11 @@ add_executable(stream_f.exe stream.f mysecond.c)
 # see https://www.scivision.dev/cmake-openmp/ for more details
 
 find_package(OpenMP COMPONENTS C Fortran)
-# Use a generator expression to link OpenMP to the executables
-target_link_libraries(
-  stream_c.exe 
-  PRIVATE
-  $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>
-)
-
-target_link_libraries(
-  stream_f.exe 
-  PRIVATE
-  $<$<BOOL:${OpenMP_Fortran_FOUND}>:OpenMP::OpenMP_Fortran>
-)
+target_link_libraries(stream_c.exe $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>)
+target_link_libraries(stream_f.exe $<$<BOOL:${OpenMP_Fortran_FOUND}>:OpenMP::OpenMP_Fortran>)
 
 # Per @scivision, ignore the build directory
+# (see https://www.scivision.dev/cmake-auto-gitignore-build-dir/)
 if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
-  # Git auto-ignore out-of-source build directory
   file(GENERATE OUTPUT .gitignore CONTENT "*")
 endif()

--- a/stream.f
+++ b/stream.f
@@ -117,11 +117,8 @@ C     .. Intrinsic Functions ..
 C
       INTRINSIC dble,max,min,nint,sqrt
 C     ..
-C     .. Arrays in Common ..
-      DOUBLE PRECISION a(ndim),b(ndim),c(ndim)
-C     ..
-C     .. Common blocks ..
-*     COMMON a,b,c
+C     .. Allocatable arrays
+       DOUBLE PRECISION, ALLOCATABLE :: a(:),b(:),c(:)
 C     ..
 C     .. Data statements ..
       DATA avgtime/4*0.0D0/,mintime/4*1.0D+36/,maxtime/4*0.0D0/
@@ -145,6 +142,8 @@ C     ..
       WRITE (*,FMT=9030) '--'
       WRITE (*,FMT=9030) 'The *best* time for each test is used'
       WRITE (*,FMT=9030) '*EXCLUDING* the first and last iterations'
+
+      ALLOCATE (a(ndim),b(ndim),c(ndim))
 
 !$OMP PARALLEL
 !$OMP MASTER


### PR DESCRIPTION
This is an attempt at a more generic CMake support compared to #9. It also converts the Fortran code to use allocatable arrays.

The latter is because I tried this out on my macOS laptop and without the allocatable arrays you get:

```
❯ ./build/stream_f.exe
zsh: illegal hardware instruction  ./build/stream_f.exe
```

I *think* this is okay since in the fortran code we have:
```fortran
*          You may put the arrays in common or not, at your discretion.
*          There is a commented-out COMMON statement below.
*          Fortran90 "allocatable" arrays are fine, too.
```
but maybe we can summon @jdmccalpin himself and see if he is okay with this and that it doesn't violate the STREAM terms. If not, I could add some ifdefs and say `if(APPLE)` we use allocatables.

I'll also mention @scivision as, well, he writes nicer CMake code than I do and he can critique it (and I used his "ignore build dir" trick).