### PR TITLE
Modify printed precision in Fortran STREAM

### DIFF
--- a/stream.f
+++ b/stream.f
@@ -233,7 +233,7 @@ C     ..
       WRITE (*,FMT=9040)
       DO 100 j = 1,4
           avgtime(j) = avgtime(j)/dble(ntimes-1)
-          WRITE (*,FMT=9050) label(j),n*bytes(j)*nbpw/mintime(j)/1.0D6,
+          WRITE (*,FMT=9050) label(j),n/1.0D6*bytes(j)*nbpw/mintime(j),
      $      avgtime(j),mintime(j),maxtime(j)
   100 CONTINUE
       PRINT *,'----------------------------------------------------'
@@ -246,7 +246,7 @@ C     ..
  9030 FORMAT (1x,a,i3,a,a)
  9040 FORMAT ('Function',5x,'Rate (MB/s)  Avg time   Min time  Max time'
      $       )
- 9050 FORMAT (a,4 (f10.4,2x))
+ 9050 FORMAT (a,f10.1,2x,3(f10.6,2x))
       END
 
 *-------------------------------------


### PR DESCRIPTION
In some situations fortran didn't have enough space to print transfer rates, instead showing ********** MB/s.  This change reduces the precision to only 1 digit after the decimal for transfer rate, and increases it to 6 digits for times.

This aligns with the C version more closely.