### PR TITLE
Add support for OpenMP Target offload - C only

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -42,6 +42,7 @@
 /*-----------------------------------------------------------------------*/
 # include <stdio.h>
 # include <unistd.h>
+# include <stdlib.h>
 # include <math.h>
 # include <float.h>
 # include <limits.h>
@@ -91,7 +92,7 @@
  *          per array.
  */
 #ifndef STREAM_ARRAY_SIZE
-#   define STREAM_ARRAY_SIZE	10000000
+#   define STREAM_ARRAY_SIZE	10000000l
 #endif
 
 /*  2) STREAM runs each kernel "NTIMES" times and reports the *best* result
@@ -176,9 +177,9 @@
 #define STREAM_TYPE double
 #endif
 
-static STREAM_TYPE	a[STREAM_ARRAY_SIZE+OFFSET],
-			b[STREAM_ARRAY_SIZE+OFFSET],
-			c[STREAM_ARRAY_SIZE+OFFSET];
+static STREAM_TYPE*	a = NULL;
+static STREAM_TYPE*	b = NULL;
+static STREAM_TYPE*	c = NULL;
 
 static double	avgtime[4] = {0}, maxtime[4] = {0},
 		mintime[4] = {FLT_MAX,FLT_MAX,FLT_MAX,FLT_MAX};
@@ -213,6 +214,10 @@ main()
     ssize_t		j;
     STREAM_TYPE		scalar;
     double		t, times[4][NTIMES];
+
+    a= calloc((STREAM_ARRAY_SIZE+OFFSET),sizeof(STREAM_TYPE));
+    b= calloc((STREAM_ARRAY_SIZE+OFFSET),sizeof(STREAM_TYPE));
+    c= calloc((STREAM_ARRAY_SIZE+OFFSET),sizeof(STREAM_TYPE));
 
     /* --- SETUP --- determine precision and check timing --- */
 

--- a/stream.c
+++ b/stream.c
@@ -99,7 +99,7 @@
  *          per array.
  */
 #ifndef STREAM_ARRAY_SIZE
-#   define STREAM_ARRAY_SIZE	1000000000l
+#   define STREAM_ARRAY_SIZE	10000000l
 #endif
 
 /*  2) STREAM runs each kernel "NTIMES" times and reports the *best* result


### PR DESCRIPTION
OpenMP now allows to offload the compute to accelerators, typically GPUs.
This PR adds the necessary pragmas to make this an option.
The GPU offload is enabled with the OMPGPU macro. The compiler must of course support it, too.
Furthermore, if both OMPGPU and OMPGPU_UNIFIED macros are specified, the explicit GPU memory movement is disabled, and the OpenMP unified memory semantics is used instead.

Note that the PR also includes the switch from the static arrays to dynamically allocated memory.
This was needed for two reasons:
1) unified memory is only guaranteed to work with dynamic memory allocation
2) many compilers limit the size of the static buffers, thus making it impossible to increase the size to accommodate for the needs of modern GPUs